### PR TITLE
Run lint (but don’t fail on errors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "standard",
     "start": "npm run build && ./scripts/serve",
     "stories": "start-storybook -p 6006",
-    "test": "jest && npm run export",
+    "test": "jest && npm run lint & npm run export",
     "test:update": "jest -u"
   },
   "repository": {


### PR DESCRIPTION
For now I just want lint to run. Later it can block CI, but too many warnings/errors atm enable that.