### PR TITLE
Normalize testRegex

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,6 @@
     "moduleNameMapper": {
       "\\.(css|scss)$": "<rootDir>/tests/__mocks__/styleMock.js"
     },
-    "testRegex": "(\/tests\/.*\\.(test|spec))\\.jsx?$"
+    "testRegex": "(/tests/.*\\.(test|spec))\\.jsx?$"
   }
 }


### PR DESCRIPTION
Whenever I update package.json it changes the regex to this. I can’t remember where I copy-pasted this from but I guess they felt forward-slashes needed to be escaped.