### PR TITLE
Remove timestamp’s startDate default

### DIFF
--- a/components/timestamp.js
+++ b/components/timestamp.js
@@ -18,8 +18,7 @@ export default class Timestamp extends Component {
   }
 
   static defaultProps = {
-    onChange: () => {},
-    startDate: null,
+    onChange: () => {}
   }
 
   constructor (props) {


### PR DESCRIPTION
It’s a required proptype, makes little sense to default it.